### PR TITLE
Add role enum for admins

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,20 @@ generator client {
 }
 
 model User {
-  id    String @id @default(uuid())
-  name  String
+  id      String  @id @default(uuid())
+  name    String
+  isAdmin Boolean
+  roles   Role[]?
+  plan    Plan?
+}
+
+enum Role {
+  edit
+  view
+  full
+}
+
+enum Plan {
+  free
+  paid
 }

--- a/src/application/user.ts
+++ b/src/application/user.ts
@@ -1,7 +1,9 @@
 import { User, UserRepository } from "../domain/user";
 
-export const createUser = (repo: UserRepository) => async (name: string): Promise<User> => {
-  return repo.create({ name });
+export const createUser = (repo: UserRepository) => async (
+  data: Omit<User, "id">,
+): Promise<User> => {
+  return repo.create(data);
 };
 
 export const getUser = (repo: UserRepository) => async (id: string): Promise<User | null> => {

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,7 +1,24 @@
-export interface User {
+export type Subscription = "paid" | "free"
+
+export type Role = "edit" | "view" | "full"
+
+export interface BaseUser {
   id: string
   name: string
+  isAdmin: boolean
 }
+
+export interface AdminUser extends BaseUser {
+  isAdmin: true
+  roles: Role[]
+}
+
+export interface RegularUser extends BaseUser {
+  isAdmin: false
+  plan: Subscription
+}
+
+export type User = AdminUser | RegularUser
 
 export interface UserRepository {
   create(data: Omit<User, "id">): Promise<User>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { greet, User } from "./domain/user"
 import * as Effect from "effect/Effect"
 
-const user: User = { id: "1", name: "Alice" }
+const user: User = { id: "1", name: "Alice", isAdmin: false, plan: "free" }
 
 Effect.runPromise(greet(user)).then(console.log)

--- a/src/infrastructure/InMemoryUserRepository.ts
+++ b/src/infrastructure/InMemoryUserRepository.ts
@@ -5,7 +5,7 @@ export class InMemoryUserRepository implements UserRepository {
   private users = new Map<string, User>();
 
   async create(data: Omit<User, "id">): Promise<User> {
-    const user: User = { id: randomUUID(), ...data };
+    const user = { id: randomUUID(), ...data } as User;
     this.users.set(user.id, user);
     return user;
   }
@@ -17,7 +17,7 @@ export class InMemoryUserRepository implements UserRepository {
   async update(id: string, data: Partial<Omit<User, "id">>): Promise<User | null> {
     const user = this.users.get(id);
     if (!user) return null;
-    const updated = { ...user, ...data };
+    const updated = { ...user, ...data } as User;
     this.users.set(id, updated);
     return updated;
   }

--- a/src/presentation/server.ts
+++ b/src/presentation/server.ts
@@ -18,12 +18,17 @@ const prisma = new PrismaClient({
 const repo = createPrismaUserRepository(prisma);
 
 app.post("/users", async (req: Request, res: Response): Promise<void> => {
-  const name = req.body.name;
+  const { name, isAdmin, roles, plan } = req.body;
   if (!name) {
     res.status(400).json({ error: "name is required" });
     return;
   }
-  const user = await createUser(repo)(name);
+
+  const data = isAdmin
+    ? { name, isAdmin: true, roles: Array.isArray(roles) ? roles : [] }
+    : { name, isAdmin: false, plan: plan ?? "free" };
+
+  const user = await createUser(repo)(data);
   res.status(201).json(user);
 });
 


### PR DESCRIPTION
## Summary
- introduce `Role` enum and use it in user model
- update Prisma schema to store roles with the new enum

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684547cd0088832aadfa2b6d42b0bb26